### PR TITLE
Release/4.4.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.4.2
+current_version = 4.4.3
 commit = False
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.4.1
+current_version = 4.4.2
 commit = False
 tag = False
 

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -6,7 +6,7 @@ env:
   DEFAULT_PLATFORM: '["linux"]'
   MATRIX_PLATFORM: '["linux", "macos"]'
   BASE_TAG: "genomehubs/blobtoolkit"
-  VERSION: 4.4.2
+  VERSION: 4.4.3
 
 on:
   workflow_call:

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -6,7 +6,7 @@ env:
   DEFAULT_PLATFORM: '["linux"]'
   MATRIX_PLATFORM: '["linux", "macos"]'
   BASE_TAG: "genomehubs/blobtoolkit"
-  VERSION: 4.4.1
+  VERSION: 4.4.2
 
 on:
   workflow_call:

--- a/.hostbumpversion.cfg
+++ b/.hostbumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.4.0
+current_version = 4.4.1
 commit = False
 tag = False
 

--- a/.pipelinebumpversion.cfg
+++ b/.pipelinebumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.4.1
+current_version = 4.4.2
 commit = False
 tag = False
 

--- a/.prebumpversion.cfg
+++ b/.prebumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 4.4.1
+current_version = 4.4.2
 commit = False
 tag = False

--- a/.prebumpversion.cfg
+++ b/.prebumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 4.4.2
+current_version = 4.4.3
 commit = False
 tag = False

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BlobToolKit (v4.4.2)
+# BlobToolKit (v4.4.3)
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![DOI](https://zenodo.org/badge/150091036.svg)](https://zenodo.org/badge/latestdoi/150091036)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ BlobToolKit is described in our [BlobToolKit paper](https://doi.org/10.1534/g3.1
 > G3: GENES, GENOMES, GENETICS April 1, 2020 vol. 10 no. 4 1361-1374;
 > https://doi.org/10.1534/g3.119.400908
 
+
+## NextFlow pipeline
+
+The recommended way to run a full set of analyses for BlobToolKit is via the [sanger-tol/blobtoolkit](https://pipelines.tol.sanger.ac.uk/blobtoolkit) NextFlow pipeline. This is the actively supported version of the pipeline as used in production by the [Tree of Life Programme](https://www.sanger.ac.uk/programme/tree-of-life/) at the [Wellcome Sanger Institute](https://www.sanger.ac.uk).
+
+
 ## About
 
 Similar to [BlobTools v1](https://github.com/DRL/blobtools), **BlobTools2** is a command line tool designed to aid genome assembly QC and contaminant/cobiont detection and filtering. In addition to supporting interactive visualisation, a motivation for this reimplementation was to provide greater flexibility to include new types of information, such as [BUSCO](https://busco.ezlab.org) results and [BLAST](https://blast.ncbi.nlm.nih.gov/Blast.cgi) hit distributions.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BlobToolKit (v4.4.1)
+# BlobToolKit (v4.4.2)
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![DOI](https://zenodo.org/badge/150091036.svg)](https://zenodo.org/badge/latestdoi/150091036)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def read(*names, **kwargs):
 
 setup(
     name="blobtoolkit",  # Required
-    version="4.4.2",
+    version="4.4.3",
     description="blobtoolkit",  # Optional
     long_description="blobtoolkit",  # Optional
     long_description_content_type="text/markdown",
@@ -141,9 +141,9 @@ setup(
             "pytest-mock>=3.1.1",
             "pytest>=6.0.0",
         ],
-        "full": ["blobtoolkit-host==4.4.2", "blobtoolkit-pipeline==4.4.1"],
+        "full": ["blobtoolkit-host==4.4.2", "blobtoolkit-pipeline==4.4.3"],
         "host": ["blobtoolkit-host==4.4.2"],
-        "pipeline": ["blobtoolkit-pipeline==4.4.1"],
+        "pipeline": ["blobtoolkit-pipeline==4.4.3"],
     },
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def read(*names, **kwargs):
 
 setup(
     name="blobtoolkit",  # Required
-    version="4.4.1",
+    version="4.4.2",
     description="blobtoolkit",  # Optional
     long_description="blobtoolkit",  # Optional
     long_description_content_type="text/markdown",
@@ -141,8 +141,8 @@ setup(
             "pytest-mock>=3.1.1",
             "pytest>=6.0.0",
         ],
-        "full": ["blobtoolkit-host==4.4.0", "blobtoolkit-pipeline==4.4.1"],
-        "host": ["blobtoolkit-host==4.4.0"],
+        "full": ["blobtoolkit-host==4.4.2", "blobtoolkit-pipeline==4.4.1"],
+        "host": ["blobtoolkit-host==4.4.2"],
         "pipeline": ["blobtoolkit-pipeline==4.4.1"],
     },
     entry_points={

--- a/src/blobtoolkit-host/pip_install_latest.sh
+++ b/src/blobtoolkit-host/pip_install_latest.sh
@@ -7,6 +7,7 @@ PLATFORM=$1
 if [ -z $PLATFORM ]; then
     echo USAGE: ./pip_install_latest.sh linux_x86_64
     echo    OR: ./pip_install_latest.sh macosx_10_9_x86_64
+    echo    OR: ./pip_install_latest.sh macosx_11_0_arm64
     exit 1
 fi
 

--- a/src/blobtoolkit-host/setup.py
+++ b/src/blobtoolkit-host/setup.py
@@ -24,7 +24,7 @@ def read(*names, **kwargs):
 
 setup(
     name="blobtoolkit-host",  # Required
-    version="4.4.0",
+    version="4.4.1",
     description="blobtoolkit-host",  # Optional
     long_description="blobtoolkit-host",  # Optional
     long_description_content_type="text/markdown",

--- a/src/blobtoolkit-host/src/lib/host.py
+++ b/src/blobtoolkit-host/src/lib/host.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-member, too-many-branches, too-many-statements, too-many-locals, W0603, W0703
 
 """
-Host a collection of BlobDirs.
+Deprecated. Host a collection of BlobDirs.
 
 Usage:
     blobtoolkit-host [--port INT]  [--api-port INT]
@@ -19,6 +19,15 @@ Options:
     --hostname STRING     Hostname used to connect to API. [Default: localhost]
     -h, --help            Show this
     -v, --version         Show version number
+
+The blobtoolkit-host command has been deprecated and will be removed in a future release.
+
+Including the BlobToolKit API and Viewer in a pip package has caused issues with the 
+size of the package and hosting limits on PyPi.
+
+Please use the alternative installation instructions in the BlobToolKit wiki at
+https://github.com/genomehubs/blobtoolkit/wiki/Installation to set up the 
+BlobToolKit API and Viewer standalone executables directly or as docker containers.
 
 """
 
@@ -42,6 +51,20 @@ from docopt import docopt
 from .version import __version__
 
 PIDS = []
+
+DEPRECATION_NOTICE = """
+Deprecated.
+
+The blobtoolkit-host command has been deprecated and will be removed in a future release.
+
+Including the BlobToolKit API and Viewer in a pip package has caused issues with the 
+size of the package and hosting limits on PyPi.
+
+Please use the alternative installation instructions in the BlobToolKit wiki at
+https://github.com/genomehubs/blobtoolkit/wiki/Installation to set up the 
+BlobToolKit API and Viewer standalone executables directly or as docker containers.
+
+"""
 
 
 def iter_user_procs(process):
@@ -205,6 +228,7 @@ def start_viewer(port, api_port, hostname):
 
 def main(args):
     """Entrypoint for blobtools host."""
+    print(DEPRECATION_NOTICE, file=sys.stderr)
     global PIDS
     directory = args["DIRECTORY"]
     if directory != "_":

--- a/src/blobtoolkit-host/src/lib/version.py
+++ b/src/blobtoolkit-host/src/lib/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 """blobtoolkit version."""
 
-__version__ = "blobtoolkit-host v4.4.0"
+__version__ = "blobtoolkit-host v4.4.1"

--- a/src/blobtoolkit-pipeline/requirements.txt
+++ b/src/blobtoolkit-pipeline/requirements.txt
@@ -7,6 +7,6 @@ tqdm==4.64.1
 ujson==5.7.0
 
 defusedxml==0.7.1
-requests==2.28.1
+requests>=2.28.1
 snakemake==7.19.1
 pulp==2.7.0

--- a/src/blobtoolkit-pipeline/setup.py
+++ b/src/blobtoolkit-pipeline/setup.py
@@ -104,7 +104,7 @@ setup(
         "tqdm==4.64.1",
         "ujson>=5.7.0",
         "defusedxml==0.7.1",
-        "requests==2.28.1",
+        "requests>=2.28.1",
         "snakemake==7.19.1",
         "pulp==2.7.0",
     ],  # Optional

--- a/src/blobtoolkit-pipeline/setup.py
+++ b/src/blobtoolkit-pipeline/setup.py
@@ -24,7 +24,7 @@ def read(*names, **kwargs):
 
 setup(
     name="blobtoolkit-pipeline",  # Required
-    version="4.4.1",
+    version="4.4.2",
     description="blobtoolkit-pipeline",  # Optional
     long_description="blobtoolkit-pipeline",  # Optional
     long_description_content_type="text/markdown",

--- a/src/blobtoolkit-pipeline/src/README.md
+++ b/src/blobtoolkit-pipeline/src/README.md
@@ -1,4 +1,4 @@
-# BTK Pipeline v4.4.1
+# BTK Pipeline v4.4.2
 
 Splits original pipeline into sub-pipelines that can be run independently or using the `blobtoolkit.smk` meta pipeline.
 

--- a/src/blobtoolkit-pipeline/src/blobtoolkit_pipeline.py
+++ b/src/blobtoolkit-pipeline/src/blobtoolkit_pipeline.py
@@ -50,5 +50,8 @@ def cli(rename=None):
             if entry_point.name == args["<command>"]:
                 subcommand = entry_point.load()
                 sys.exit(subcommand(rename))
+    elif "--help" in args and args["--help"]:
+        print(__doc__)
+        exit(0)
     print(docs)
     raise DocoptExit

--- a/src/blobtoolkit-pipeline/src/lib/extract_busco_genes.py
+++ b/src/blobtoolkit-pipeline/src/lib/extract_busco_genes.py
@@ -48,6 +48,8 @@ def parse_busco_file(fh, ofh, status, busco_id):
         if line.startswith(">"):
             header = line.strip()
             title = ""
+            # remove trailing "|-" or "|+" from header if present
+            header = re.sub(r"\|[\-+]+$", "", header)
             if header.startswith(f">{busco_id}"):
                 seq_id = header.split("|")[-1]
                 title = f">{seq_id}={busco_id}={status}"
@@ -110,7 +112,7 @@ def parse_tarred_busco_directory(file_pattern, ofh, utf8reader, busco_seqs):
 
 def parse_busco_directory(file_pattern, ofh, busco_file):
     """Parse a plain busco_directory."""
-    files = glob.glob(f"{busco_file}/*/*.faa")
+    files = glob.glob(f"{Path(busco_file).resolve()}/*/*.faa")
     for file in files:
         match = file_pattern.search(file)
         status, busco_id = match.groups()

--- a/src/blobtoolkit-pipeline/src/lib/version.py
+++ b/src/blobtoolkit-pipeline/src/lib/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 """blobtoolkit version."""
 
-__version__ = "blobtoolkit-pipeline v4.4.1"
+__version__ = "blobtoolkit-pipeline v4.4.2"

--- a/src/blobtools/blobtools.py
+++ b/src/blobtools/blobtools.py
@@ -62,7 +62,7 @@ def suggest_option(command):
     options_list = options.get(command, [])
     options_list.append("full")
     LOGGER.error(
-        f"The `blobtools {command}` command is not available, to enable this option use{' one of' if len(options_list)>1 else ''}:"
+        f"The `blobtools {command}` command is not available, to enable this option use{' one of' if len(options_list) > 1 else ''}:"
     )
     for option in options_list:
         print(
@@ -110,4 +110,10 @@ def cli():
             "'%s %s' is not a valid command", args["<tool>"], args["<command>"]
         )
         sys.exit(1)
+    elif "--help" in args and args["--help"]:
+        print(__doc__)
+        exit(0)
+    elif "--version" in args and args["--version"]:
+        print(__version__)
+        exit(0)
     raise DocoptExit

--- a/src/blobtools/lib/version.py
+++ b/src/blobtools/lib/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 """blobtoolkit version."""
 
-__version__ = "blobtoolkit v4.4.1"
+__version__ = "blobtoolkit v4.4.2"

--- a/src/blobtools/lib/version.py
+++ b/src/blobtools/lib/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 """blobtoolkit version."""
 
-__version__ = "blobtoolkit v4.4.2"
+__version__ = "blobtoolkit v4.4.3"

--- a/src/btk/lib/version.py
+++ b/src/btk/lib/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 """blobtoolkit version."""
 
-__version__ = "blobtoolkit v4.4.1"
+__version__ = "blobtoolkit v4.4.2"

--- a/src/btk/lib/version.py
+++ b/src/btk/lib/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 """blobtoolkit version."""
 
-__version__ = "blobtoolkit v4.4.2"
+__version__ = "blobtoolkit v4.4.3"

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -21,6 +21,9 @@ WORKDIR /blobtoolkit
 
 USER blobtoolkit
 
+COPY build_tests.py /blobtoolkit
+RUN python3 build_tests.py && rm build_tests.py
+
 COPY startup.sh /blobtoolkit
 
 EXPOSE 8000 8001 8080

--- a/src/docker/blobtools/env.yaml
+++ b/src/docker/blobtools/env.yaml
@@ -7,4 +7,4 @@ dependencies:
   - python==3.9
   - seqtk==1.4
   - pip:
-      - blobtoolkit[full]==blobtoolkit==4.4.1
+      - blobtoolkit[full]==blobtoolkit==4.4.2

--- a/src/docker/blobtools/env.yaml
+++ b/src/docker/blobtools/env.yaml
@@ -7,4 +7,4 @@ dependencies:
   - python==3.9
   - seqtk==1.4
   - pip:
-      - blobtoolkit[full]==blobtoolkit==4.4.2
+      - blobtoolkit[full]==blobtoolkit==4.4.3

--- a/src/docker/build_tests.py
+++ b/src/docker/build_tests.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+"""Run a set of simple tests to check if the commands are available and working."""
+
+import subprocess
+import sys
+
+commands = [
+    ["blobtools", "--version"],
+    ["blobtools", "--help"],
+    ["blobtools", "create", "--help"],
+    ["blobtools", "replace", "--help"],
+    ["blobtools", "add", "--help"],
+    ["blobtools", "remove", "--help"],
+    ["blobtools", "validate", "--help"],
+    ["blobtools", "filter", "--help"],
+    ["blobtools", "host", "--help"],
+    ["blobtools", "view", "--help"],
+    ["btk", "pipeline", "--help"],
+    ["btk", "pipeline", "run", "--help"],
+    ["btk", "pipeline", "add-summary-to-metadata", "--help"],
+    ["btk", "pipeline", "chunk-fasta", "--help"],
+    ["btk", "pipeline", "count-busco-genes", "--help"],
+    ["btk", "pipeline", "extract-busco-genes", "--help"],
+    ["btk", "pipeline", "generate-config", "--help"],
+    ["btk", "pipeline", "generate-static-images", "--help"],
+    ["btk", "pipeline", "transfer-completed", "--help"],
+    ["btk", "pipeline", "unchunk-blast", "--help"],
+    ["btk", "pipeline", "window-stats", "--help"],
+]
+
+
+def run_command(command):
+    try:
+        subprocess.run(
+            command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        print(f"Command {' '.join(command)}: SUCCESS")
+    except subprocess.CalledProcessError:
+        print(f"Command {' '.join(command)}: FAIL")
+        return False
+    return True
+
+
+def main():
+    all_success = True
+    for command in commands:
+        if not run_command(command):
+            all_success = False
+
+    if not all_success:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/docker/env.yaml
+++ b/src/docker/env.yaml
@@ -15,4 +15,4 @@ dependencies:
   - samtools==1.15.1
   - seqtk==1.4
   - pip:
-      - blobtoolkit[full]==4.4.2
+      - blobtoolkit[full]==4.4.3

--- a/src/docker/env.yaml
+++ b/src/docker/env.yaml
@@ -15,4 +15,4 @@ dependencies:
   - samtools==1.15.1
   - seqtk==1.4
   - pip:
-      - blobtoolkit[full]==4.4.1
+      - blobtoolkit[full]==4.4.2


### PR DESCRIPTION
## Summary by Sourcery

This pull request updates the version of the BlobToolKit to 4.4.3, deprecates the `blobtoolkit-host` command, recommends the use of the NextFlow pipeline, and fixes issues with BUSCO headers and file path resolution.

Bug Fixes:
- Fixes an issue where BUSCO headers were not parsed correctly by removing trailing '|-' or '|+'.
- Fixes an issue where the blobtoolkit pipeline would not resolve the path to the busco file.

Build:
- Updates the versions of blobtoolkit packages in setup.py.
- Updates the versions of blobtoolkit packages in the docker environment files.

CI:
- Updates the version number in the changes workflow file.

Documentation:
- Adds a section to the README.md file recommending the use of the NextFlow pipeline for running a full set of analyses for BlobToolKit.

Tests:
- Adds a script to the Dockerfile to run a set of simple tests to check if the commands are available and working.

Chores:
- Updates the version number in multiple files to 4.4.3.
- Deprecates the `blobtoolkit-host` command, which will be removed in a future release, and adds a deprecation notice to the command-line interface.