### PR TITLE
Replace pkg_resources entry point loading

### DIFF
--- a/src/blobtoolkit-pipeline/src/blobtoolkit_pipeline.py
+++ b/src/blobtoolkit-pipeline/src/blobtoolkit_pipeline.py
@@ -24,11 +24,19 @@ See 'blobtoolkit-pipeline <command> --help' for more information on a specific c
 """
 
 import sys
+from importlib.metadata import entry_points
 
 from docopt import DocoptExit
 from docopt import docopt
 from lib.version import __version__
-from pkg_resources import working_set
+
+
+def iter_entry_points(group):
+    """Return entry points for a group across supported Python versions."""
+    discovered = entry_points()
+    if hasattr(discovered, "select"):
+        return discovered.select(group=group)
+    return discovered.get(group, ())
 
 
 def cli(rename=None):
@@ -46,7 +54,7 @@ def cli(rename=None):
         args = {"<command>": command}
     if args["<command>"]:
         # load <command> from entry_points
-        for entry_point in working_set.iter_entry_points("blobtoolkit_pipeline.subcmd"):
+        for entry_point in iter_entry_points("blobtoolkit_pipeline.subcmd"):
             if entry_point.name == args["<command>"]:
                 subcommand = entry_point.load()
                 sys.exit(subcommand(rename))

--- a/src/blobtools/blobtools.py
+++ b/src/blobtools/blobtools.py
@@ -44,15 +44,23 @@ examples:
 
 import os
 import sys
+from importlib.metadata import entry_points
 
 from docopt import DocoptExit
 from docopt import docopt
-from pkg_resources import working_set
 from tolkein import tolog
 
 from .lib.version import __version__
 
 LOGGER = tolog.logger(__name__)
+
+
+def iter_entry_points(group):
+    """Return entry points for a group across supported Python versions."""
+    discovered = entry_points()
+    if hasattr(discovered, "select"):
+        return discovered.select(group=group)
+    return discovered.get(group, ())
 
 
 def suggest_option(command):
@@ -98,7 +106,7 @@ def cli():
                     sys.argv.insert(command_index + 1, "--replace")
                 args["<command>"] = "add"
             sys.argv[command_index] = "add"
-        for entry_point in working_set.iter_entry_points("%s.subcmd" % args["<tool>"]):
+        for entry_point in iter_entry_points("%s.subcmd" % args["<tool>"]):
             if entry_point.name == args["<command>"]:
                 try:
                     subcommand = entry_point.load()

--- a/src/btk/btk.py
+++ b/src/btk/btk.py
@@ -18,15 +18,23 @@ See 'btk <command> --help' for more information on a specific command.
 import os
 import subprocess
 import sys
+from importlib.metadata import entry_points
 
 from docopt import DocoptExit
 from docopt import docopt
-from pkg_resources import working_set
 from tolkein import tolog
 
 from .lib.version import __version__
 
 LOGGER = tolog.logger(__name__)
+
+
+def iter_entry_points(group):
+    """Return entry points for a group across supported Python versions."""
+    discovered = entry_points()
+    if hasattr(discovered, "select"):
+        return discovered.select(group=group)
+    return discovered.get(group, ())
 
 
 def suggest_option(command):
@@ -72,7 +80,7 @@ def cli():
     if "<command>" in args and args["<command>"]:
         args.update({"<tool>": os.path.basename(sys.argv[0])})
         # load <command> from entry_points
-        for entry_point in working_set.iter_entry_points("%s.subcmd" % args["<tool>"]):
+        for entry_point in iter_entry_points("%s.subcmd" % args["<tool>"]):
             if entry_point.name == args["<command>"]:
                 if entry_point.name == args["<command>"]:
                     try:


### PR DESCRIPTION
## Summary
- replace `pkg_resources.working_set` entry point discovery with `importlib.metadata.entry_points()` in the `blobtools`, `btk`, and `blobtoolkit-pipeline` CLIs
- keep compatibility with the older Python 3.9 `entry_points()` return shape while using the newer `.select()` API when available
- remove the remaining first-party runtime imports of `pkg_resources`

Addresses #273

## Validation
- Not run locally
- `git diff --check HEAD~1..HEAD`
- `rg 'pkg_resources|working_set'` (no matches)
- Remote CI: no checks reported on this branch at the initial check