### PR TITLE
Document blobplot taxonomic rank parameters

### DIFF
--- a/docs/command-line/commands.md
+++ b/docs/command-line/commands.md
@@ -41,10 +41,38 @@ blobtools filter --query "gc > 0.4 AND read_cov > 10" \
 
 ### view
 
-Export BlobDir data:
+Export BlobDir data or plots:
 
 ```bash
 blobtools view --out tsv \
+               input_directory/
+```
+
+Blob plots use the category field stored in the BlobDir plot metadata by
+default. Hits added with the default taxrule create category fields named
+`bestsumorder_<rank>`, such as `bestsumorder_phylum`,
+`bestsumorder_family`, and `bestsumorder_genus`.
+
+Use the `catField` parameter to render a blob plot at a different taxonomic
+rank from the command line:
+
+```bash
+blobtools view --plot \
+               --view blob \
+               --format png \
+               --out ./ \
+               --param catField=bestsumorder_family \
+               input_directory/
+```
+
+The same parameter can be passed without `--plot` when rendering through the
+viewer-backed export path:
+
+```bash
+blobtools view --view blob \
+               --format png \
+               --out ./ \
+               --param catField=bestsumorder_genus \
                input_directory/
 ```
 

--- a/docs/command-line/tutorials.md
+++ b/docs/command-line/tutorials.md
@@ -43,6 +43,28 @@ blobtools host --port 8080 my_blobdir/
 
 Then visit `http://localhost:8080` in your browser.
 
+### Step 5: Export a Blob Plot at Another Taxonomic Rank
+
+By default, blob plots use the category field recorded in the BlobDir plot
+metadata. When taxonomic hits are added with the default taxrule, BlobTools
+creates rank-specific fields named `bestsumorder_<rank>`, for example
+`bestsumorder_phylum`, `bestsumorder_family`, and `bestsumorder_genus`.
+
+Pass the desired category field with `--param catField=...` when exporting a
+blob plot:
+
+```bash
+blobtools view --plot \
+               --view blob \
+               --format png \
+               --out ./ \
+               --param catField=bestsumorder_family \
+               my_blobdir/
+```
+
+Replace `bestsumorder_family` with another available rank field, such as
+`bestsumorder_genus`, to colour the blob plot at that taxonomic level.
+
 ## Filtering Contigs
 
 Use the filter command to subset your data:


### PR DESCRIPTION
## Summary
- document how to use `--param catField=<taxrule>_<rank>` when exporting blob plots from the command line
- add examples for family/genus-level blob plot exports in the commands reference and tutorial
- clarify that default taxonomic fields from the default taxrule are named like `bestsumorder_phylum`, `bestsumorder_family`, and `bestsumorder_genus`

Fixes #277

## Validation
- Not run locally
- Static validation only: `git diff --check`

## Summary by Sourcery

Document how to select taxonomic rank-specific category fields when exporting blob plots from the command line.

Documentation:
- Explain default taxrule-derived category field names used for blob plots (e.g. bestsumorder_phylum, bestsumorder_family, bestsumorder_genus).
- Add command reference examples showing use of the catField parameter to render blob plots at different taxonomic ranks from the CLI.
- Extend the tutorial with a step demonstrating blob plot export at alternate taxonomic ranks using catField.