### PR TITLE
Document hosting multiple local BlobDirs

### DIFF
--- a/docs/viewer/index.md
+++ b/docs/viewer/index.md
@@ -27,10 +27,10 @@ The viewer provides:
 
 ## Quick Start
 
-To visualize a local BlobDir dataset:
+To visualize local BlobDir datasets, host the parent directory that contains one or more BlobDirs:
 
 ```bash
-blobtools host --port 8080 /path/to/blobdir/
+blobtools host --port 8080 /path/to/datasets/
 ```
 
-Then open `http://localhost:8080` in your browser.
+Then open `http://localhost:8080/view/all` in your browser. See [Local Hosting](local-hosting) for the expected directory layout and Docker usage.

--- a/docs/viewer/local-hosting.md
+++ b/docs/viewer/local-hosting.md
@@ -5,22 +5,60 @@ title: Local Hosting
 
 # Local Hosting with BlobTools Host
 
-The BlobTools host command starts an interactive web server for visualizing your blob plot data locally.
+The BlobTools host command starts an interactive web server for visualizing your blob plot data locally. The command expects a directory containing one or more BlobDirs.
 
 ## Starting the Viewer
 
+For a single BlobDir, pass the parent directory that contains the BlobDir:
+
 ```bash
-blobtools host --port 8080 /path/to/blobdir/
+blobtools host --port 8080 /path/to/datasets/
 ```
 
-Then open your browser and navigate to `http://localhost:8080`
+where the directory contains a BlobDir such as:
+
+```text
+datasets/
+`-- example-1/
+    `-- meta.json
+```
+
+Then open your browser and navigate to `http://localhost:8080/view/all`. You can also search for `all` in the viewer to list available datasets.
+
+## Hosting Multiple BlobDirs
+
+To host more than one local dataset, place each BlobDir in the same parent directory and host that parent:
+
+```text
+datasets/
+|-- example-1/
+|   `-- meta.json
+`-- example-2/
+    `-- meta.json
+```
+
+```bash
+blobtools host --api-port 8000 --port 8080 /path/to/datasets/
+```
+
+Open `http://localhost:8080/view/all` to browse the indexed datasets, or open a dataset directly using a URL such as `http://localhost:8080/view/all/dataset/example-1`.
+
+With Docker, mount the parent directory to `/blobtoolkit/datasets` and host that mounted path:
+
+```bash
+docker run -d --rm --name btk \
+    -v "$PWD/datasets:/blobtoolkit/datasets" \
+    -p 8000:8000 -p 8080:8080 \
+    genomehubs/blobtoolkit:latest \
+    blobtools host --api-port 8000 --port 8080 /blobtoolkit/datasets
+```
 
 ## Port Configuration
 
 To use a different port:
 
 ```bash
-blobtools host --port 3000 /path/to/blobdir/
+blobtools host --port 3000 /path/to/datasets/
 ```
 
 ## Connecting from Remote Servers


### PR DESCRIPTION
## Summary
- clarify that `blobtools host` serves the parent directory containing one or more BlobDirs
- document the `/view/all` URL used to browse locally hosted datasets
- add a Docker example that mounts the datasets parent directory and hosts it

Fixes #278

## Validation
- Not run locally
- Static validation only: `git diff --check`, `git diff --cached --check`, `git show --stat --oneline --check HEAD`

## Summary by Sourcery

Document how to host one or multiple local BlobDirs with blobtools host and clarify the expected directory layout and access URLs.

Documentation:
- Expand local hosting documentation to explain hosting parent directories containing one or more BlobDirs, including example directory structures and URLs.
- Document use of the /view/all route for browsing locally hosted datasets and add a Docker-based hosting example.
- Update quick-start docs to reference hosting the datasets parent directory and link to detailed local hosting guidance.